### PR TITLE
Example of handling frames

### DIFF
--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -27,7 +27,7 @@ from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.validation.jsonschema import SchemaValidationError
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend
-from qiskit.pulse.channels import PulseChannel, DriveChannel
+from qiskit.pulse.channels import PulseChannel
 from qiskit.pulse import Schedule
 
 logger = logging.getLogger(__name__)

--- a/qiskit/compiler/assembler.py
+++ b/qiskit/compiler/assembler.py
@@ -27,7 +27,7 @@ from qiskit.qobj.utils import MeasLevel, MeasReturnType
 from qiskit.validation.jsonschema import SchemaValidationError
 from qiskit.providers import BaseBackend
 from qiskit.providers.backend import Backend
-from qiskit.pulse.channels import PulseChannel
+from qiskit.pulse.channels import PulseChannel, DriveChannel
 from qiskit.pulse import Schedule
 
 logger = logging.getLogger(__name__)
@@ -301,6 +301,10 @@ def _parse_pulse_args(backend, qubit_lo_freq, meas_lo_freq, qubit_lo_range,
     qubit_lo_range = qubit_lo_range or getattr(backend_config, 'qubit_lo_range', None)
     meas_lo_range = meas_lo_range or getattr(backend_config, 'meas_lo_range', None)
 
+    frames = None
+    if hasattr(backend_config, 'frames'):
+        frames = backend_config.frames()
+
     dynamic_reprate_enabled = getattr(backend_config, 'dynamic_reprate_enabled', False)
 
     rep_time = rep_time or getattr(backend_config, 'rep_times', None)
@@ -326,6 +330,7 @@ def _parse_pulse_args(backend, qubit_lo_freq, meas_lo_freq, qubit_lo_range,
                            memory_slot_size=memory_slot_size,
                            rep_time=rep_time,
                            parametric_pulses=parametric_pulses,
+                           frames=frames,
                            **run_config)
     run_config = RunConfig(**{k: v for k, v in run_config_dict.items() if v is not None})
 

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -757,14 +757,20 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
                                             "information.".format(self.backend_name))
 
     def frames(self) -> List[Channel]:
-        """Gets the frames of the backend"""
+        """
+        Gets the frames of the backend in serializable format.
+
+        Returns:
+            frames: A List of lists. Sublist i is a list of channel names that belong
+                to frame i.
+        """
         n_qubits = self.n_qubits
         frames = []
         for qubit in range(n_qubits):
-            frame_ = [DriveChannel(qubit)]
+            frame_ = [DriveChannel(qubit).name]
             for ctrl in range(n_qubits):
                 try:
-                    frame_ += self.control((ctrl, qubit))
+                    frame_ += [_.name for _ in self.control((ctrl, qubit))]
                 except BackendConfigurationError:
                     pass
 

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -765,7 +765,7 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             for ctrl in range(n_qubits):
                 try:
                     frame_ += self.control((ctrl, qubit))
-                except QiskitError:
+                except BackendConfigurationError:
                     pass
 
             frames.append(frame_)

--- a/qiskit/providers/models/backendconfiguration.py
+++ b/qiskit/providers/models/backendconfiguration.py
@@ -756,6 +756,22 @@ class PulseBackendConfiguration(QasmBackendConfiguration):
             raise BackendConfigurationError("This backend - '{}' does not provide channel "
                                             "information.".format(self.backend_name))
 
+    def frames(self) -> List[Channel]:
+        """Gets the frames of the backend"""
+        n_qubits = self.n_qubits
+        frames = []
+        for qubit in range(n_qubits):
+            frame_ = [DriveChannel(qubit)]
+            for ctrl in range(n_qubits):
+                try:
+                    frame_ += self.control((ctrl, qubit))
+                except QiskitError:
+                    pass
+
+            frames.append(frame_)
+
+        return frames
+
     def get_channel_qubits(self, channel: Channel) -> List[int]:
         """
         Return a list of indices for qubits which are operated on directly by the given ``channel``.

--- a/qiskit/pulse/__init__.py
+++ b/qiskit/pulse/__init__.py
@@ -434,6 +434,7 @@ from qiskit.pulse.channels import (
     AcquireChannel,
     ControlChannel,
     DriveChannel,
+    Frame,
     MeasureChannel,
     MemorySlot,
     RegisterSlot,

--- a/qiskit/pulse/channels.py
+++ b/qiskit/pulse/channels.py
@@ -181,6 +181,11 @@ class ControlChannel(PulseChannel):
     prefix = 'u'
 
 
+class Frame(PulseChannel):
+    """Channel to manage frames."""
+    prefix = 'f'
+
+
 class AcquireChannel(Channel):
     """Acquire channels are used to collect data."""
     prefix = 'a'

--- a/qiskit/pulse/transforms.py
+++ b/qiskit/pulse/transforms.py
@@ -331,6 +331,10 @@ def resolve_frames(schedules: List[Schedule], frames: List[List[str]]) -> List[S
     Returns:
         new_schedules: A list of new schedules where frames have been replaced with
             their corresponding Drive, Control, and/or Measure channels.
+
+    Raises:
+        PulseError: if an instruction other than ShiftPhase, SetPhase, ShiftFrequency,
+            SetFrequency is applied to a Frame.
     """
     if frames is None:
         return schedules
@@ -376,6 +380,10 @@ def _resolve_channel(name: str) -> chans.Channel:
 
     Returns:
         channel: The channel of the appropriate type.
+
+    Raises:
+        PulseError: If the channel is not a DriveChannel, ControlChannel, or
+            MeasureChannel.
     """
     if name[0] == 'd':
         return chans.DriveChannel(int(name[1:]))


### PR DESCRIPTION
### Summary
This PR is a limited example of how one could handle frames in Qiskit.

### Details and comments
The is a demo using only changes of the phase of a frame. It is exemplified by running the following code
```
from qiskit.pulse import Frame, DriveChannel
from qiskit import assemble
import qiskit.pulse as pulse

with pulse.build() as test:
    pulse.shift_phase(2.0, Frame(0))
```
Then doing `assemble(test, backend)` gives a `PulseQObj` that contains
```
experiments=[PulseQobjExperiment([
    PulseQobjInstruction(name="fc", t0=0, ch="d0", phase=2.0), 
    PulseQobjInstruction(name="fc", t0=0, ch="u1", phase=2.0)], header=...
```


